### PR TITLE
Windowsでファイルパスのパースに失敗するバグを修正

### DIFF
--- a/src/commands/compose.ts
+++ b/src/commands/compose.ts
@@ -100,7 +100,7 @@ export async function compose (resource?: Uri) {
       );
 
       if (result === openInBrowser) {
-        commands.executeCommand('vscode.open', Uri.parse(item.url));
+        commands.executeCommand('vscode.open', item.url);
       }
     } catch (error) {
       // tslint:disable-next-line:no-console

--- a/src/commands/openItem.ts
+++ b/src/commands/openItem.ts
@@ -51,7 +51,7 @@ export function openItem (storagePath?: string) {
     }
 
     try {
-      const fileUri = Uri.parse(`file://${storagePath}/${item.id}.md`);
+      const fileUri = Uri.file(`${storagePath}/${item.id}.md`);
 
       // 拡張機能用ディレクトリがない場合初期化
       if (!fs.existsSync(storagePath)) {

--- a/src/explorers/nodes/qiitaItemsNode.ts
+++ b/src/explorers/nodes/qiitaItemsNode.ts
@@ -16,6 +16,6 @@ export class QiitaItem extends TreeItem {
     super(item.title, collapsibleState);
   }
 
-  public resourceUri  = Uri.parse('file:///text.md'); // Hack: アイコンをMarkdownのものに
+  public resourceUri  = Uri.file('text.md'); // Hack: アイコンをMarkdownのものに
   public contextValue = 'qiitaItems';
 }


### PR DESCRIPTION
`Uri.parse`はNode.jsの`new URL.constructor`と挙動が異なり、ファイルパスのパースに失敗していたので、適切なメソッド `Uri.file`に変更。

---

<!-- [ ] を [x] に置き換えてチェックを入れてください -->
- [x] 同様のpull requestが無いか調べました。
